### PR TITLE
invoke函数增加对设备初始化完成的判断，如果未初始化完成，事件将被加入待执行队列

### DIFF
--- a/core/kerkee.js
+++ b/core/kerkee.js
@@ -33,7 +33,8 @@
 		callbackId : 0,
 		processingMsg : false,
 		isReady : false,
-		isNotifyReady : false
+		isNotifyReady : false,
+        initCompletePromise: null
 	};
 
 	ApiBridge.create = function()
@@ -173,6 +174,49 @@
 		});
 	}
 
+    if (Promise) {
+        ApiBridge.Promise = Promise
+    } else {
+        ApiBridge.Promise = easyPromise;
+    }
+    function easyPromise(callback) {
+        var PENDING = 'pending';
+        var DONE = 'done';
+        var doneCallbacksArr = [];
+
+        var state = PENDING;
+
+        var resolve = function() {
+            state = DONE;
+            dispatch(doneCallbacksArr);
+        }
+
+        this.then = function(cb) {
+            if (state === DONE) {
+                setTimeout(function () {
+                    cb();
+                }, 0);
+            }
+
+            if (state === PENDING) {
+                doneCallbacksArr.push(cb);
+            }
+        }
+
+        var dispatch = function(cbs) {
+            var cb;
+            while (cb = cbs.shift()) {
+                setTimeout((function (fn) {
+                    return function () {
+                        fn();
+                    };
+                })(cb), 0);
+            }
+        }
+
+        callback(resolve);
+    }
+
 	var	_Configs =
     {
         isOpenJSLog:false,
@@ -266,14 +310,16 @@
 
 	kerkee.invoke = function(clz, method, args, callback)
 	{
-		if (callback)
-		{
-			ApiBridge.callNative(clz, method, args, callback);
-		}
-		else
-		{
-			ApiBridge.callNative(clz, method, args);
-		}
+        ApiBridge.initCompletePromise.then(function() {
+            if (callback)
+            {
+                ApiBridge.callNative(clz, method, args, callback);
+            }
+            else
+            {
+                ApiBridge.callNative(clz, method, args);
+            }
+        });
 	};
 
 	kerkee.onSetImage = function(srcSuffix, desUri)
@@ -454,38 +500,31 @@
 		_window.open = window.open;
 	};
 
+    ApiBridge.initCompletePromise = new ApiBridge.Promise(function(resolve) {
+        ApiBridge.onBridgeInitComplete(function(aConfigs)
+        {
+            if (aConfigs)
+            {
+                if (aConfigs.hasOwnProperty('isOpenJSLog'))
+                {
+                    _Configs.isOpenJSLog = aConfigs.isOpenJSLog;
+                }
+                if (aConfigs.hasOwnProperty('isOpenNativeXHR'))
+                {
+                    _Configs.isOpenNativeXHR = aConfigs.isOpenNativeXHR;
+                }
+            }
 
-	ApiBridge.onBridgeInitComplete(function(aConfigs)
-	{
-		if (aConfigs)
-		{
-			if (aConfigs.hasOwnProperty('isOpenJSLog'))
-        	{
-        		_Configs.isOpenJSLog = aConfigs.isOpenJSLog;
-        	}
-        	if (aConfigs.hasOwnProperty('isOpenNativeXHR'))
-       		{
-       			_Configs.isOpenNativeXHR = aConfigs.isOpenNativeXHR;
-       		}
-		}
+            if (_Configs.isOpenJSLog)
+            {
+                global.console.log = ApiBridge.log;
+            }
 
-//		alert(JSON.stringify(aConfigs));
-		if (_Configs.isOpenJSLog)
-		{
-			global.console.log = ApiBridge.log;
-		}
-//		else
-//		{
-//			global.console.log = null;
-//			global.console.log = _Configs.sysLog;
-//		}
+            ApiBridge.onNativeInitComplete(ApiBridge.onDeviceReady);
 
-		ApiBridge.onNativeInitComplete(ApiBridge.onDeviceReady);
+            resolve();
+        });
+    })
 
-		// kerkee.onDeviceReady(function(){
-		// alert('onDeviceReady');
-		// });
-
-	});
 
 })(window);


### PR DESCRIPTION
仅有调用native api时才需要判断设备是否初始化完成。因此页面中其他没有调用native api的逻辑没必要等待onBridgeInitComplete完成后再执行。
